### PR TITLE
Bugfix Sketch Version 40

### DIFF
--- a/Unsplash It.sketchplugin/Contents/Sketch/unsplashit.cocoascript
+++ b/Unsplash It.sketchplugin/Contents/Sketch/unsplashit.cocoascript
@@ -47,7 +47,7 @@ var onRun = function (context) {
                 var imageData = NSImage.alloc().initWithData( get(imageURL) );
 
                 fill.setFillType(4);
-                fill.setPatternImage( imageData );
+                fill.setImage([[MSImageData alloc] initWithImage: imageData convertColorSpace: false]); // Change to Sketch V40 or higher. 
 			    fill.setPatternFillType(1);
 
             }


### PR DESCRIPTION
In this new Sketch update, setPatternImage() has been deprecated.

The solution is easy, we have to change the line 50,
fill.setPatternImage( imageData ), for  fill.setImage([[MSImageData
alloc] initWithImage: imageData convertColorSpace: false]);

For the moment, works on the version v40 and higher. This is a fast solution to work with this fantastic plugin. 
